### PR TITLE
update to allow installing new versions

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -15,7 +15,7 @@ release_file_prefix="$ASDF_DOWNLOAD_PATH/$TOOL_NAME-$ASDF_INSTALL_VERSION"
 download_release "$ASDF_INSTALL_VERSION" "$release_file_prefix"
 
 #  Extract contents of archive file
-if [ -f "${release_file_prefix}.zip" ] ; then
+if [ -f "${release_file_prefix}.zip" ]; then
   unzip -q "${release_file_prefix}.zip" -d "$ASDF_DOWNLOAD_PATH" || fail "Could not extract ${release_file_prefix}.zip"
 else
   tar -xzf "${release_file_prefix}.tar.gz" -C "$ASDF_DOWNLOAD_PATH" || fail "Could not extract ${release_file_prefix}.tar.gz"

--- a/bin/download
+++ b/bin/download
@@ -10,14 +10,16 @@ source "${plugin_dir}/lib/utils.bash"
 
 mkdir -p "$ASDF_DOWNLOAD_PATH"
 
-# TODO: Adapt this to proper extension and adapt extracting strategy.
-release_file="$ASDF_DOWNLOAD_PATH/$TOOL_NAME-$ASDF_INSTALL_VERSION.zip"
+release_file_prefix="$ASDF_DOWNLOAD_PATH/$TOOL_NAME-$ASDF_INSTALL_VERSION"
 
-# Download tar.gz file to the download directory
-download_release "$ASDF_INSTALL_VERSION" "$release_file"
+download_release "$ASDF_INSTALL_VERSION" "$release_file_prefix"
 
-#  Extract contents of zip file into the download directory
-unzip -q "$release_file" -d "$ASDF_DOWNLOAD_PATH" || fail "Could not extract $release_file"
+#  Extract contents of archive file
+if [ -f "${release_file_prefix}.zip" ] ; then
+  unzip -q "${release_file_prefix}.zip" -d "$ASDF_DOWNLOAD_PATH" || fail "Could not extract ${release_file_prefix}.zip"
+else
+  tar -xzf "${release_file_prefix}.tar.gz" -C "$ASDF_DOWNLOAD_PATH" || fail "Could not extract ${release_file_prefix}.tar.gz"
+fi
 
-# Remove the tar.gz file since we don't need to keep it
-rm "$release_file"
+# Remove the archive file since we don't need to keep it
+rm -f "${release_file_prefix}.tar.gz" "${release_file_prefix}.zip"

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -37,18 +37,24 @@ list_all_versions() {
 }
 
 download_release() {
-  local version filename url platform arch
+  local version filename found url platform arch
   version="$1"
-  filename="$2"
+  filename="$2" # we will treat this like a prefix
 
   platform=$(getPlatform)
   arch=$(getArch)
 
-  # TODO: Adapt the release URL convention for tf-summarize
-  url="$GH_REPO/releases/download/v${version}/${TOOL_NAME}_${platform}_${arch}.zip"
+  found=false
+  for extension in zip tar.gz ; do
+    url="$GH_REPO/releases/download/v${version}/${TOOL_NAME}_${platform}_${arch}.${extension}"
 
-  echo "* Downloading $TOOL_NAME release $version..."
-  curl "${curl_opts[@]}" -o "$filename" -C - "$url" || fail "Could not download $url"
+    echo "* Downloading $TOOL_NAME release $version (trying $extension)..."
+    if curl "${curl_opts[@]}" -o "${filename}.${extension}" -C - "$url" ; then
+      found=true
+      break
+    fi
+  done
+  $found || fail "Could not download $url"
 }
 
 install_version() {

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -37,24 +37,25 @@ list_all_versions() {
 }
 
 download_release() {
-  local version filename found url platform arch
+  local version filename found url_prefix platform arch
   version="$1"
   filename="$2" # we will treat this like a prefix
 
   platform=$(getPlatform)
   arch=$(getArch)
 
+  url_prefix="$GH_REPO/releases/download/v${version}/${TOOL_NAME}_${platform}_${arch}"
+
   found=false
   for extension in zip tar.gz ; do
-    url="$GH_REPO/releases/download/v${version}/${TOOL_NAME}_${platform}_${arch}.${extension}"
 
     echo "* Downloading $TOOL_NAME release $version (trying $extension)..."
-    if curl "${curl_opts[@]}" -o "${filename}.${extension}" -C - "$url" ; then
+    if curl "${curl_opts[@]}" -o "${filename}.${extension}" -C - "${url_prefix}.${extension}" ; then
       found=true
       break
     fi
   done
-  $found || fail "Could not download $url"
+  $found || fail "Could not download $url_prefix(.tar.gz|.zip)"
 }
 
 install_version() {

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -47,10 +47,10 @@ download_release() {
   url_prefix="$GH_REPO/releases/download/v${version}/${TOOL_NAME}_${platform}_${arch}"
 
   found=false
-  for extension in zip tar.gz ; do
+  for extension in zip tar.gz; do
 
     echo "* Downloading $TOOL_NAME release $version (trying $extension)..."
-    if curl "${curl_opts[@]}" -o "${filename}.${extension}" -C - "${url_prefix}.${extension}" ; then
+    if curl "${curl_opts[@]}" -o "${filename}.${extension}" -C - "${url_prefix}.${extension}"; then
       found=true
       break
     fi


### PR DESCRIPTION
After release v0.3.5, tf-summarize archives some platform release archives as a `.tar.gz` instead of a `.zip`. This adds logic to try both, so it will work for old and new installs across platforms.